### PR TITLE
System.autoLoader fix

### DIFF
--- a/extensions/autoLoader.js
+++ b/extensions/autoLoader.js
@@ -2,12 +2,11 @@ System.autoLoad = (name, deps, fn) => {
     deps = deps || [];
     deps = deps.map(n => System.normalizeSync(n, name));
     var loadedModules = [];
-    var mustWait = false;
-    deps.every(mName => {
+    var mustWait = deps.some(mName => {
         const m = System.get(mName);
         if (!m) {
             mustWait = true;
-            return false;
+            return true;
         }
         loadedModules.push(m);
     });


### PR DESCRIPTION
Fixes https://github.com/vazco/universe-ecmascript/issues/3

I took the liberty of changing `deps.every` to `deps.some` as it makes more sense with the `mustWait` condition.

The original implementation with `deps.every` was returning at the first iteration because it was not returning `true` so the loop was ended prematurely. With `deps.some` it is not needed because its the truthy value that breaks the loop, not the falsy.
